### PR TITLE
fix: correct skills directory path resolution

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -217,8 +217,8 @@ export function installClaudeSkillsForFix(root: string): void {
 }
 
 function installClaudeSkills(root: string): void {
-  // skills/ is always a sibling of dist/ in the npm package
-  const skillsSource = join(dirname(new URL(import.meta.url).pathname), "..", "skills");
+  // skills/ is always a sibling of dist/ in the npm package (dist/commands/ → dist/ → package root → skills/)
+  const skillsSource = join(dirname(new URL(import.meta.url).pathname), "../..", "skills");
 
   if (!existsSync(skillsSource)) {
     warn("Skills not found in package — skipping");


### PR DESCRIPTION
## Summary
- Fixed incorrect path resolution for `skills/` directory in `installClaudeSkills()`
- The compiled file is at `dist/commands/setup.js`, so `..` only went up to `dist/` — not the package root where `skills/` lives
- Changed `".."` to `"../.."` to correctly resolve to the package root

## Root Cause
```
Before: dist/commands/ + ".."    → dist/skills/        ✗ (doesn't exist → silently skipped)
After:  dist/commands/ + "../.." → package-root/skills/ ✓ (11 skills found)
```

## Test plan
- [ ] Run `codebase setup` after `npm install` — skills should now be copied to `~/.claude/skills/`
- [ ] Verify all 11 `.skill` files are installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)