### PR TITLE
chore(dependabot): stop applying labels removed by the org taxonomy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,7 @@ updates:
       # Skip major version bumps — review manually
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    labels:
-      - "dependencies"
+    labels: []
 
   # Keep GitHub Actions up to date
   - package-ecosystem: "github-actions"
@@ -29,6 +28,4 @@ updates:
       actions:
         patterns:
           - "*"
-    labels:
-      - "dependencies"
-      - "ci"
+    labels: []


### PR DESCRIPTION
The org label taxonomy (ZySec-AI/.github `labels.yml`) no longer contains `dependencies` or `type:chore`.

Dependabot applies `dependencies` to every PR it opens unless `labels: []` is set explicitly — omitting the key is not enough. Without this, the org label guard would strip the label on every Dependabot PR indefinitely.

No change to update schedules, ecosystems or grouping.